### PR TITLE
Drop support for old ruby versions

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -69,7 +69,7 @@ module Random::Formatter
   #   prng.hex #=> "eb693ec8252cd630102fd0d0fb7c3485"
   #   prng.hex #=> "91dc3bfb4de5b11d029d376634589b61"
   def hex(n=nil)
-    random_bytes(n).unpack("H*")[0]
+    random_bytes(n).unpack1("H*")
   end
 
   # Random::Formatter#base64 generates a random base64 string.

--- a/securerandom.gemspec
+++ b/securerandom.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Interface for secure random number generator.}
   spec.description   = %q{Interface for secure random number generator.}
   spec.homepage      = "https://github.com/ruby/securerandom"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.metadata["homepage_uri"] = spec.homepage

--- a/test/ruby/test_random_formatter.rb
+++ b/test/ruby/test_random_formatter.rb
@@ -27,9 +27,9 @@ module Random::Formatter
     end
 
     def test_base64
-      assert_equal(16, @it.base64.unpack('m*')[0].size)
+      assert_equal(16, @it.base64.unpack1('m*').size)
       17.times do |idx|
-        assert_equal(idx, @it.base64(idx).unpack('m*')[0].size)
+        assert_equal(idx, @it.base64(idx).unpack1('m*').size)
       end
     end
 


### PR DESCRIPTION
As `Random.urandom` is not supported before ruby 2.5, at least.