### PR TITLE
Increase speed of UUID generation

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -142,10 +142,10 @@ module Random::Formatter
   # See RFC 4122 for details of UUID.
   #
   def uuid
-    ary = random_bytes(16).unpack("NnnnnN")
-    ary[2] = (ary[2] & 0x0fff) | 0x4000
-    ary[3] = (ary[3] & 0x3fff) | 0x8000
-    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    ary = random_bytes(16)
+    ary.setbyte(6, (ary.getbyte(6) & 0x0f) | 0x40)
+    ary.setbyte(8, (ary.getbyte(8) & 0x3f) | 0x80)
+    ary.unpack("H8H4H4H4H12").join(?-)
   end
 
   private def gen_random(n)


### PR DESCRIPTION
This change speeds up UUID generation by somewhere between 10-40%. Originally implemented as part of https://github.com/robotblake/hakusho.

## Benchmark Methodology

* First install the `benchmark-ips` gem and then create a file called `benchmark.rb` in the root of the repo with the following content.

  ```ruby
  require "benchmark/ips"

  lib = File.expand_path("../lib", __FILE__)
  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
  require "securerandom"

  Benchmark.ips do |x|
    x.report(`git rev-parse --short HEAD`.strip) do
      SecureRandom.uuid
    end
    x.save! "uuid.out"
    x.compare!
  end
  ```

* Checkout the `v0.2.0` tag, and run `ruby benchmark.rb`.
* Checkout the `b587b8c` commit, and run `ruby benchmark.rb`.

## Benchmark Results

```
~/Projects/securerandom ❯ git checkout v0.2.0
HEAD is now at 62ca282 Bump up v0.2.0

~/Projects/securerandom ❯ ruby benchmark.rb 
Warming up --------------------------------------
             62ca282    93.716k i/100ms
Calculating -------------------------------------
             62ca282    941.790k (± 0.3%) i/s -      4.780M in   5.074975s

~/Projects/securerandom ❯ git checkout b587b8c
Previous HEAD position was 62ca282 Bump up v0.2.0
HEAD is now at b587b8c Increase speed of UUID generation

~/Projects/securerandom ❯ ruby benchmark.rb
Warming up --------------------------------------
             b587b8c   131.060k i/100ms
Calculating -------------------------------------
             b587b8c      1.312M (± 0.4%) i/s -      6.684M in   5.093688s

Comparison:
             b587b8c:  1312244.3 i/s
             62ca282:   941790.2 i/s - 1.39x  (± 0.00) slower
```