### PR TITLE
Rename `choose` to `random_string` and make it public

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -152,7 +152,7 @@ module Random::Formatter
     self.bytes(n)
   end
 
-  # Random::Formatter#choose generates a string that randomly draws from a
+  # Random::Formatter#random_string generates a string that randomly draws from a
   # source array of characters.
   #
   # The argument _source_ specifies the array of characters from which
@@ -164,9 +164,9 @@ module Random::Formatter
   #
   #   require 'random/formatter'
   #
-  #   prng.choose([*'l'..'r'], 16) #=> "lmrqpoonmmlqlron"
-  #   prng.choose([*'0'..'9'], 5)  #=> "27309"
-  private def choose(source, n)
+  #   prng.random_string([*'l'..'r'], 16) #=> "lmrqpoonmmlqlron"
+  #   prng.random_string([*'0'..'9'], 5)  #=> "27309"
+  def random_string(source, n)
     size = source.size
     m = 1
     limit = size
@@ -195,6 +195,8 @@ module Random::Formatter
     result
   end
 
+  alias_method :choose, :random_string
+
   ALPHANUMERIC = [*'A'..'Z', *'a'..'z', *'0'..'9']
   # Random::Formatter#alphanumeric generates a random alphanumeric string.
   #
@@ -212,6 +214,6 @@ module Random::Formatter
   #   prng.alphanumeric(10) #=> "i6K93NdqiH"
   def alphanumeric(n=nil)
     n = 16 if n.nil?
-    choose(ALPHANUMERIC, n)
+    random_string(ALPHANUMERIC, n)
   end
 end

--- a/lib/securerandom.rb
+++ b/lib/securerandom.rb
@@ -23,7 +23,7 @@ require 'random/formatter'
 #
 # * alphanumeric
 # * base64
-# * choose
+# * random_string
 # * gen_random
 # * hex
 # * rand

--- a/test/ruby/test_random_formatter.rb
+++ b/test/ruby/test_random_formatter.rb
@@ -83,6 +83,14 @@ module Random::Formatter
       end
     end
 
+    def test_random_string
+      80.times do |n|
+        rs = @it.random_string([*'a'..'f'], n)
+        assert_match(/\A[a-f]*\z/, rs)
+        assert_equal(n, rs.length)
+      end
+    end
+
     def assert_in_range(range, result, mesg = nil)
       assert(range.cover?(result), build_message(mesg, "Expected #{result} to be in #{range}"))
     end


### PR DESCRIPTION
context: https://bugs.ruby-lang.org/issues/18183#change-93775
Originally this was a PR against ruby/ruby but it was suggested here: https://github.com/ruby/ruby/pull/4878 that I submit it here instead.