### PR TITLE
Update UUID documentation with RFC9562 links

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -165,7 +165,7 @@ module Random::Formatter
   #
   # The result contains 122 random bits (15.25 random bytes).
   #
-  # See RFC4122[https://www.rfc-editor.org/rfc/rfc4122] for details of UUID.
+  # See RFC9562[https://www.rfc-editor.org/rfc/rfc9562] for details of UUIDv4.
   #
   def uuid
     ary = random_bytes(16)
@@ -204,8 +204,7 @@ module Random::Formatter
   # Note that this method cannot be made reproducible because its output
   # includes not only random bits but also timestamp.
   #
-  # See draft-ietf-uuidrev-rfc4122bis[https://datatracker.ietf.org/doc/draft-ietf-uuidrev-rfc4122bis/]
-  # for details of UUIDv7.
+  # See RFC9562[https://www.rfc-editor.org/rfc/rfc9562] for details of UUIDv7.
   #
   # ==== Monotonicity
   #
@@ -242,7 +241,7 @@ module Random::Formatter
   #
   # Counters and other mechanisms for stronger guarantees of monotonicity are
   # not implemented.  Applications with stricter requirements should follow
-  # {Section 6.2}[https://www.ietf.org/archive/id/draft-ietf-uuidrev-rfc4122bis-07.html#monotonicity_counters]
+  # {Section 6.2}[https://www.rfc-editor.org/rfc/rfc9562.html#name-monotonicity-and-counters]
   # of the specification.
   #
   def uuid_v7(extra_timestamp_bits: 0)


### PR DESCRIPTION
RFC9562 was released almost two weeks ago, so we can replace the "draft" UUIDv7 URL with the final RFC URL too.  RFC9562 obsoletes RFC4122, so I replaced its link as well.