### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/securerandom

### DIFF
--- a/securerandom.gemspec
+++ b/securerandom.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/securerandom which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata